### PR TITLE
Move observeOn() in SharedSequence class so it works as intended.

### DIFF
--- a/rxkotlin-traits/src/main/kotlin/com/jurajbegovac/rxkotlin/traits/driver/Observable+Driver.kt
+++ b/rxkotlin-traits/src/main/kotlin/com/jurajbegovac/rxkotlin/traits/driver/Observable+Driver.kt
@@ -6,13 +6,10 @@ import rx.Observable
 /** Created by juraj begovac on 06/06/2017. */
 
 fun <Element> Observable<Element>.asDriver(onErrorJustReturn: Element): Driver<Element> =
-    SharedSequence(this.onErrorReturn { onErrorJustReturn }
-                       .observeOn(DriverTraits.scheduler), DriverTraits)
+    SharedSequence(this.onErrorReturn { onErrorJustReturn }, DriverTraits)
 
 fun <Element> Observable<Element>.asDriver(onErrorDriveWith: (Throwable) -> Driver<Element>): Driver<Element> =
-    SharedSequence(this.onErrorResumeNext { onErrorDriveWith(it).source }
-                       .observeOn(DriverTraits.scheduler), DriverTraits)
+    SharedSequence(this.onErrorResumeNext { onErrorDriveWith(it).source }, DriverTraits)
 
 fun <Element> Observable<Element>.asDriverCompleteOnError(): Driver<Element> =
-    SharedSequence(this.onErrorResumeNext { Observable.empty() }
-                       .observeOn(DriverTraits.scheduler), DriverTraits)
+    SharedSequence(this.onErrorResumeNext { Observable.empty() }, DriverTraits)

--- a/rxkotlin-traits/src/main/kotlin/com/jurajbegovac/rxkotlin/traits/shared_sequence/SharedSequence.kt
+++ b/rxkotlin-traits/src/main/kotlin/com/jurajbegovac/rxkotlin/traits/shared_sequence/SharedSequence.kt
@@ -15,7 +15,7 @@ open class SharedSequence<Traits : SharedSequenceTraits, Element>(source: Observ
                                                                   internal val traits: Traits) {
   companion object {}
   
-  internal val source: Observable<Element> = traits.share(source)
+  internal val source: Observable<Element> = traits.share(source.observeOn(traits.scheduler))
   
   class Safe<Traits : SharedSequenceTraits, Element>(source: Observable<Element>,
                                                      traits: Traits) : SharedSequence<Traits, Element>(


### PR DESCRIPTION
SharedSequence should be on the trait thread and use its share strategy. The problem is that, with current implementation, shared sequence does not switch to the trait thread, instead we have to do it manually outside. The share strategy is ok.